### PR TITLE
Fix project access control across all pages

### DIFF
--- a/blueprint-ai/src/components/workspace/NoProjectAccess.tsx
+++ b/blueprint-ai/src/components/workspace/NoProjectAccess.tsx
@@ -1,0 +1,43 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Shield, Users } from 'lucide-react';
+
+interface NoProjectAccessProps {
+  title?: string;
+  description?: string;
+  showCard?: boolean;
+}
+
+export function NoProjectAccess({ 
+  title = "No Project Access",
+  description = "You don't have access to any projects yet. Please contact your workspace administrator to be added to a project to start viewing data.",
+  showCard = true 
+}: NoProjectAccessProps) {
+  const content = (
+    <Alert className="border-amber-200 bg-amber-50 text-amber-800">
+      <Shield className="h-4 w-4" />
+      <AlertDescription className="flex flex-col gap-3">
+        <div>
+          <h3 className="font-medium text-amber-900 mb-1">{title}</h3>
+          <p className="text-sm">{description}</p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-amber-700 bg-amber-100 rounded-md p-2">
+          <Users className="h-3 w-3" />
+          <span>Contact your administrator to request project access</span>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+
+  if (showCard) {
+    return (
+      <Card className="bg-card/50 border border-border/50">
+        <CardContent className="p-6">
+          {content}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return content;
+}

--- a/blueprint-ai/src/lib/providers/WorkspaceContextBridge.tsx
+++ b/blueprint-ai/src/lib/providers/WorkspaceContextBridge.tsx
@@ -1,0 +1,37 @@
+import { ReactNode, useEffect } from 'react';
+import { useWorkspace } from '../workspace-context';
+import { useWorkspaceStore } from '../stores/workspaceStore';
+
+interface WorkspaceContextBridgeProps {
+  children: ReactNode;
+}
+
+// This component bridges the gap between the existing WorkspaceContext
+// and our Zustand store, keeping them in sync
+export function WorkspaceContextBridge({ children }: WorkspaceContextBridgeProps) {
+  const {
+    currentWorkspace,
+    currentProject,
+    loading
+  } = useWorkspace();
+
+  const {
+    setCurrentWorkspace: storeSetWorkspace,
+    setCurrentProject: storeSetProject
+  } = useWorkspaceStore();
+
+  // Sync context -> store (including null values)
+  useEffect(() => {
+    storeSetWorkspace(currentWorkspace);
+  }, [currentWorkspace, storeSetWorkspace]);
+
+  useEffect(() => {
+    // Always sync the current project, even if it's null
+    // This is important when a user has no projects
+    if (!loading) {
+      storeSetProject(currentProject);
+    }
+  }, [currentProject, loading, storeSetProject]);
+
+  return <>{children}</>;
+}

--- a/blueprint-ai/src/lib/stores/workspaceStore.ts
+++ b/blueprint-ai/src/lib/stores/workspaceStore.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Workspace, Project } from '../types/workspace';
+
+// This store is a bridge between the existing WorkspaceContext and our Tanstack Query hooks
+// It doesn't manage the workspace/project state directly, but provides a way to access it
+// from components that don't have access to the WorkspaceContext
+
+interface WorkspaceState {
+  // These values will be set by the WorkspaceContextBridge component
+  currentWorkspace: Workspace | null;
+  currentProject: Project | null;
+
+  // Actions - these are just placeholders that will be overridden by the bridge
+  setCurrentWorkspace: (workspace: Workspace | null) => void;
+  setCurrentProject: (project: Project | null) => void;
+}
+
+export const useWorkspaceStore = create<WorkspaceState>()(
+  persist(
+    (set) => ({
+      currentWorkspace: null,
+      currentProject: null,
+
+      // These are placeholder implementations that will be overridden
+      setCurrentWorkspace: (workspace: Workspace | null) => {
+        set({ currentWorkspace: workspace });
+      },
+
+      setCurrentProject: (project: Project | null) => {
+        set({ currentProject: project });
+      },
+    }),
+    {
+      name: 'blueprint-workspace-storage',
+      // Only persist these fields
+      partialize: (state) => ({
+        currentWorkspace: state.currentWorkspace,
+        currentProject: state.currentProject,
+      }),
+    }
+  )
+);
+
+// Make the store accessible globally for direct access in other modules
+// This is useful for modules that don't have access to React hooks
+if (typeof window !== 'undefined') {
+  (window as any).__ZUSTAND_WORKSPACE_STORE__ = useWorkspaceStore;
+}


### PR DESCRIPTION
## Summary
Fixed the issue where users without project access could still see data in the dashboard and other pages. Now all pages consistently show a "No Project Access" message when a user has no projects assigned.

## Changes Made

### 1. **Fixed WorkspaceContextBridge Synchronization**
- Updated `WorkspaceContextBridge.tsx` to properly sync null values when a user has no projects
- Fixed TypeScript errors in workspace store to accept null values
- Ensures the Zustand store correctly reflects when a user has no project access

### 2. **Created Reusable NoProjectAccess Component**
- Created `NoProjectAccess.tsx` component with consistent styling and messaging
- Supports both card and non-card layouts for different use cases
- Provides clear instructions for users to contact administrators

### 3. **Updated All Main Pages**
Updated the following pages to check for project access and show appropriate messages:
- **Dashboard** (`EnhancedDashboard.tsx`)
- **Test Runs** (`TestRunsPage.tsx`) 
- **Test Reviews** (`ReviewsPage.tsx`)
- **Test Library** (`TestCaseLibraryPage.tsx`)
- **Reports** (`ReportsPage.tsx`)
- **Create Test Case** (`CreateTestCasePage.tsx`)

### 4. **Consistent Implementation Pattern**
Each page now follows this pattern:
1. Check if workspace/projects are loading
2. If user has no projects, show the `NoProjectAccess` component
3. Only show actual page content when user has project access

### 5. **Improved User Experience**
- Loading states while checking project access
- Clear, consistent messaging across all pages
- Professional styling with amber color scheme for warnings
- Helpful instructions to contact administrators

## Problem Solved
Previously, when a user was not added to any project:
- ❌ Sidebar correctly showed empty projects dropdown BUT dashboard still showed data
- ❌ Other pages had inconsistent behavior

Now:
- ✅ Sidebar correctly shows empty projects dropdown
- ✅ Dashboard shows "No Project Access" message instead of data
- ✅ All other pages consistently show the same access control message

## Testing
- [x] Build passes without errors
- [x] All pages show consistent "No Project Access" message when user has no projects
- [x] Loading states work correctly
- [x] TypeScript errors resolved